### PR TITLE
Tests now always run, and don't explode.

### DIFF
--- a/build_sgxssl.sh
+++ b/build_sgxssl.sh
@@ -156,7 +156,7 @@ rm -rf $OPENSSL_VERSION || clean_and_ret 1
 cd $SGXSSL_ROOT/sgx || clean_and_ret 1
 
 make OS_ID=$OS_ID $LINUX_BUILD_FLAG || clean_and_ret 1 # will also copy the resulting files to package
-if [[ $# -gt 0 && $1 != "linux-sgx" && $2 != "linux-sgx" ]] ; then
+if [[ $1 != "linux-sgx" && $2 != "linux-sgx" ]] ; then
 	./test_app/TestApp || clean_and_ret 1 # verify everything is working ok
 fi
 make clean || clean_and_ret 1

--- a/sgx/test_app/enclave/TestEnclave.cpp
+++ b/sgx/test_app/enclave/TestEnclave.cpp
@@ -151,15 +151,11 @@ void rsa_key_gen()
 	free(buf);
 
 	BN_free(bn);
-	int do_rsa_free = 1;
-	if (evp_pkey->pkey.rsa == keypair) {
-		do_rsa_free = 0;
-	}
 
 	EVP_PKEY_free(evp_pkey);
 
-	if (do_rsa_free) {
-		RSA_free(keypair);
+	if (evp_pkey->pkey.ptr != NULL) {
+	  RSA_free(keypair);
 	}
 }
 
@@ -225,14 +221,9 @@ void ec_key_gen()
 
 	free(buf);
 
-	int do_ec_free = 1;
-	if (ec_pkey->pkey.ec == ec) {
-		do_ec_free = 0;
-	}
-
 	EVP_PKEY_free(ec_pkey);
-	if (do_ec_free) {
-		EC_KEY_free(ec);
+	if (ec_pkey->pkey.ptr != NULL) {
+	  EC_KEY_free(ec);
 	}
 }
 

--- a/sgx/test_app/sgx_t.mk
+++ b/sgx/test_app/sgx_t.mk
@@ -119,7 +119,7 @@ TestEnclave_Link_Flags := $(SGX_COMMON_CFLAGS) -Wl,--no-undefined -nostdlib -nod
 	$(Security_Link_Flags) \
 	$(SgxSSL_Link_Libraries) -L$(SGX_LIBRARY_PATH) \
 	-Wl,--whole-archive -l$(Trts_Library_Name) -Wl,--no-whole-archive \
-	-Wl,--start-group -lsgx_tstdc -lsgx_tstdcxx -lsgx_tcrypto -lsgx_tsetjmp -l$(Service_Library_Name) -Wl,--end-group \
+	-Wl,--start-group -lsgx_tstdc -lsgx_tstdcxx -lsgx_tcrypto -l$(Service_Library_Name) -Wl,--end-group \
 	-Wl,-Bstatic -Wl,-Bsymbolic -Wl,--no-undefined \
 	-Wl,-pie,-eenclave_entry -Wl,--export-dynamic  \
 	-Wl,--defsym,__ImageBase=0 \


### PR DESCRIPTION
Tested against OpenSSL 1.1.0g.
