### PR TITLE
Fix improper parsing of SGX SDK Version used in the build script

### DIFF
--- a/Linux/build_sgxssl.sh
+++ b/Linux/build_sgxssl.sh
@@ -74,7 +74,7 @@ if [[ $# -gt 0 ]] && [[ $1 == "linux-sgx" || $2 == "linux-sgx" ]] ; then
 else
 	LINUX_BUILD_FLAG=LINUX_SGX_BUILD=0
 	SGX_SDK=/opt/intel/sgxsdk
-        SGXSDK_VERSION=`/usr/bin/pkg-config --modversion $SGX_SDK/pkgconfig/libsgx_urts.pc | cut -d. -f1-2`
+        SGXSDK_VERSION=`pkg-config --modversion $SGX_SDK/pkgconfig/libsgx_urts.pc | cut -d. -f1-2`
 	if [ -f $SGX_SDK/environment ]; then
 		source $SGX_SDK/environment || clean_and_ret 1
 	else

--- a/Linux/build_sgxssl.sh
+++ b/Linux/build_sgxssl.sh
@@ -74,7 +74,7 @@ if [[ $# -gt 0 ]] && [[ $1 == "linux-sgx" || $2 == "linux-sgx" ]] ; then
 else
 	LINUX_BUILD_FLAG=LINUX_SGX_BUILD=0
 	SGX_SDK=/opt/intel/sgxsdk
-	SGXSDK_VERSION=`/bin/grep -m 1 "Version:" $SGX_SDK/pkgconfig/libsgx_urts.pc | /bin/grep -o -E "[1-9]\.[0-9]"`
+        SGXSDK_VERSION=`/usr/bin/pkg-config --modversion $SGX_SDK/pkgconfig/libsgx_urts.pc | cut -d. -f1-2`
 	if [ -f $SGX_SDK/environment ]; then
 		source $SGX_SDK/environment || clean_and_ret 1
 	else


### PR DESCRIPTION
The build script improperly detects SGX SDK v2.1.1 and therefore fails.  Using 'pkg-config' resolves this.