### PR TITLE
support ssl library

### DIFF
--- a/Linux/Makefile
+++ b/Linux/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011-2017 Intel Corporation. All rights reserved.
+# Copyright (C) 2011-2021 Intel Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -51,6 +51,7 @@ sgxssl_no_mitigation:
 clean:
 	$(MAKE) -C sgx/ clean
 	rm -rf $(PACKAGE_LIB)/$(OPENSSL_LIB) $(PACKAGE_INC)/openssl/
+	rm -rf $(PACKAGE_LIB)/$(OPENSSL_SSL_LIB)
 	rm -rf $(PACKAGE_LIB)/cve_2020_0551_load
 	rm -rf $(PACKAGE_LIB)/cve_2020_0551_cf
 

--- a/Linux/package/include/sgx_tsgxssl.edl
+++ b/Linux/package/include/sgx_tsgxssl.edl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2017 Intel Corporation. All rights reserved.
+ * Copyright (C) 2011-2021 Intel Corporation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,6 +37,20 @@ enclave {
     
     untrusted {
     	 void u_sgxssl_ftime([out, size=timeb_len] void * timeptr, uint32_t timeb_len);
+         int ocall_cc_read(int fd, [out, size = buf_len] void *buf, size_t buf_len);
+         int ocall_cc_write(int fd, [in, size = buf_len] const void *buf, size_t buf_len);
+         int ocall_cc_getenv([in, size = name_len] const char *name, size_t name_len, [out, size = buf_len] void *buf, int buf_len, [out] int *need_len);
+         uint64_t ocall_cc_fopen([in, size = filename_len] const char *filename, size_t filename_len, [in, size = mode_len] const char *mode, size_t mode_len);
+         int ocall_cc_fclose(uint64_t fp);
+         int ocall_cc_ferror(uint64_t fp);
+         int ocall_cc_feof(uint64_t fp);
+         int ocall_cc_fflush(uint64_t fp);
+         long ocall_cc_ftell(uint64_t fp);
+         int ocall_cc_fseek(uint64_t fp, long offset, int origin);
+         size_t ocall_cc_fread([out, size = total_size] void *buf, size_t total_size, size_t element_size, size_t cnt, uint64_t fp);
+         size_t ocall_cc_fwrite([in, size = total_size] const void *buf, size_t total_size, size_t element_size, size_t cnt, uint64_t fp);
+         int ocall_cc_fgets([out, size = max_cnt] char *str, int max_cnt, uint64_t fp);
+         int ocall_cc_fputs([in, size = total_size] const char *str, size_t total_size, uint64_t fp);
     };
 
     trusted {

--- a/Linux/package/include/tsgxsslio.h
+++ b/Linux/package/include/tsgxsslio.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2017 Intel Corporation. All rights reserved.
+ * Copyright (C) 2011-2021 Intel Corporation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,6 +32,12 @@
 #ifndef _TSGXSSL_IO_H_
 #define _TSGXSSL_IO_H_
 
-typedef void FILE;
+#include <stdio.h>
+
+#undef stdout
+#define stdout ((void*)1)
+#undef stderr
+#define stderr ((void*)2)
+typedef struct _IO_FILE FILE;
 
 #endif // _TSGXSSL_IO_H_

--- a/Linux/sgx/Makefile
+++ b/Linux/sgx/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011-2017 Intel Corporation. All rights reserved.
+# Copyright (C) 2011-2021 Intel Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -54,9 +54,11 @@ endif
 
 ifneq ($(MITIGATION-CVE-2020-0551),)
 	$(RM) -r $(PACKAGE_LIB)$(MITIGATION_LIB_PATH)/$(TRUSTED_LIB)
+	$(RM) -r $(PACKAGE_LIB)$(MITIGATION_LIB_PATH)/$(OPENSSL_SSL_LIB)
 	$(RM) -r $(PACKAGE_LIB)$(MITIGATION_LIB_PATH)/$(OPENSSL_LIB)
 	mkdir -p $(PACKAGE_LIB)$(MITIGATION_LIB_PATH)
 	mv $(PACKAGE_LIB)/$(OPENSSL_LIB) $(PACKAGE_LIB)$(MITIGATION_LIB_PATH)/
+	mv $(PACKAGE_LIB)/$(OPENSSL_SSL_LIB) $(PACKAGE_LIB)$(MITIGATION_LIB_PATH)/
 	mv $(PACKAGE_LIB)/$(TRUSTED_LIB) $(PACKAGE_LIB)$(MITIGATION_LIB_PATH)/
 endif
 

--- a/Linux/sgx/buildenv.mk
+++ b/Linux/sgx/buildenv.mk
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011-2020 Intel Corporation. All rights reserved.
+# Copyright (C) 2011-2021 Intel Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -73,11 +73,13 @@ endif
 ifeq ($(DEBUG), 1)
 	OBJDIR := debug
 	OPENSSL_LIB := libsgx_tsgxssl_cryptod.a
+	OPENSSL_SSL_LIB := libsgx_tsgxssl_ssld.a
 	TRUSTED_LIB := libsgx_tsgxssld.a
 	UNTRUSTED_LIB := libsgx_usgxssld.a
 else
 	OBJDIR := release
 	OPENSSL_LIB := libsgx_tsgxssl_crypto.a
+	OPENSSL_SSL_LIB := libsgx_tsgxssl_ssl.a
 	TRUSTED_LIB := libsgx_tsgxssl.a
 	UNTRUSTED_LIB := libsgx_usgxssl.a
 endif

--- a/Linux/sgx/libsgx_tsgxssl/tcommon.h
+++ b/Linux/sgx/libsgx_tsgxssl/tcommon.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2017 Intel Corporation. All rights reserved.
+ * Copyright (C) 2011-2021 Intel Corporation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -40,6 +40,7 @@
 #include "tdefines.h"
 #include "tSgxSSL_api.h"
 
+#define CC_SSL_SUCCESS 0
 
 //#define DO_SGX_LOG
 #define DO_SGX_WARN

--- a/Linux/sgx/libsgx_tsgxssl/tstdio.cpp
+++ b/Linux/sgx/libsgx_tsgxssl/tstdio.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2017 Intel Corporation. All rights reserved.
+ * Copyright (C) 2011-2021 Intel Corporation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,13 +30,242 @@
  */
 
 #include <stdio.h>
+#include <string.h>
 #include "tcommon.h"
 #include "sgx_tsgxssl_t.h"
 #include "tSgxSSL_api.h"
+#include "tsgxsslio.h"
 
 extern PRINT_TO_STDOUT_STDERR_CB s_print_cb;
 
 extern "C" {
+
+int print_with_cb(void* fp, const char* fmt, __va_list vl)
+{
+    int res = -1;
+
+    if (fp == NULL || s_print_cb == NULL) {
+        return -1;
+    }
+    int stream = -1;
+    if (fp == stdout) {
+        stream = STREAM_STDOUT;
+    } else if (fp == stderr) {
+        stream = STREAM_STDERR;
+    } else {
+        // This function is called only when fp is one of the internally implemented stdout/stderr.
+        return res;
+    } 
+    res = s_print_cb((Stream_t)stream, fmt, vl);
+    return res;
+}
+
+void *sgxssl_fopen(const char *filename, const char *mode)
+{
+    uint64_t ret = 0;
+    int res;
+
+    if (filename == NULL || mode == NULL) {
+        return NULL;
+    }
+
+    res = ocall_cc_fopen(&ret, filename, strlen(filename) + 1, mode, strlen(mode) + 1);
+    if (res != CC_SSL_SUCCESS) {
+        return NULL;
+    }
+    return (void *)ret;
+}
+
+int sgxssl_fclose(void *fp)
+{
+    int ret = -1;
+    int res;
+
+    if (fp == NULL) {
+        return -1;
+    }
+    
+    res = ocall_cc_fclose(&ret, (uint64_t)fp);
+    if (res != CC_SSL_SUCCESS) {
+        return -1;
+    }
+    return ret;
+}
+
+int sgxssl_ferror(void *fp)
+{
+    int ret = -1;
+    int res;
+
+    if (fp == NULL) {
+        return -1;
+    }
+
+    res = ocall_cc_ferror(&ret, (uint64_t)fp);
+    if (res != CC_SSL_SUCCESS) {
+	return -1;
+    }
+    return ret;
+}
+
+int sgxssl_feof(void *fp)
+{
+    int ret = 0;
+    int res;
+    
+    if (fp == NULL) {
+	return 0;
+    }
+    
+    res = ocall_cc_feof(&ret, (uint64_t)fp);
+    if (res != CC_SSL_SUCCESS) {
+	return 0;
+    }
+    return ret;
+}
+
+int sgxssl_fflush(void *fp)
+{
+    int ret = -1;
+    int res;
+
+    if (fp == NULL) {
+        return -1;
+    }
+
+    res = ocall_cc_fflush(&ret, (uint64_t)fp);
+    if (res != CC_SSL_SUCCESS) {
+        return -1;
+    }
+    return ret;
+}
+
+long sgxssl_ftell(void *fp)
+{
+    long ret = -1;
+    int res;
+
+    if (fp == NULL) {
+	return -1;
+    }
+
+    res = ocall_cc_ftell(&ret, (uint64_t)fp);
+    if (res != CC_SSL_SUCCESS) {
+        return -1;
+    }
+    return ret;
+}
+
+int sgxssl_fseek(void *fp, long offset, int origin)
+{
+    int ret = -1;
+    int res;
+
+    if (fp == NULL) {
+        return -1;
+    }
+
+    res = ocall_cc_fseek(&ret, (uint64_t)fp, offset, origin);
+    if (res != CC_SSL_SUCCESS) {
+        return -1;
+    }
+    return ret;
+}
+
+
+int sgxssl_fprintf(void *fp, const char *format, ...)
+{
+    if (s_print_cb != NULL) {
+        va_list vl;
+        va_start(vl, format);
+        int res = print_with_cb(fp, format, vl);
+        va_end(vl);
+
+	return res;
+     }
+
+    return -1;
+}
+
+int sgxssl_vfprintf(void *fp, const char *format, va_list vl)
+{
+    if (s_print_cb != NULL) {
+        int res = print_with_cb(fp, format, vl);
+        return res;
+    }
+        
+    return -1;
+}
+
+size_t sgxssl_fread(void *dest, size_t element_size, size_t cnt, void *fp)
+{
+    size_t ret = 0;
+    int res;
+
+    if (fp == NULL || dest == NULL || element_size == 0 || cnt == 0) {
+        return 0;
+    }
+    if (element_size > (SIZE_MAX - 1) / cnt + 1) {
+        return 0;
+    }
+
+    res = ocall_cc_fread(&ret, dest, element_size * cnt, element_size, cnt, (uint64_t)fp);
+    if (res != CC_SSL_SUCCESS) {
+        return 0;
+    }
+    return ret;
+}
+
+size_t sgxssl_fwrite(const void *src, size_t element_size, size_t cnt, void *fp)
+{
+    size_t ret = 0;
+    int res;
+
+    if (fp == NULL || src == NULL || element_size == 0 || cnt == 0) {
+        return 0;
+    }
+    if (element_size > (SIZE_MAX - 1) / cnt + 1) {
+        return 0;
+    }
+
+    res = ocall_cc_fwrite(&ret, src, element_size * cnt, element_size, cnt, (uint64_t)fp);
+    if (res != CC_SSL_SUCCESS) {
+        return 0;
+    }
+    return ret;
+}
+
+char *sgxssl_fgets(char *dest, int max_cnt, void *fp)
+{
+    int ret = -1;
+    int res;
+
+    if (fp == NULL || dest == NULL || max_cnt <= 0) {
+        return NULL;
+    }
+    
+    res = ocall_cc_fgets(&ret, dest, max_cnt, (uint64_t)fp);
+    if (res != CC_SSL_SUCCESS || ret < 0) {
+        return NULL;
+    }
+    return dest;
+}
+
+int sgxssl_fputs(const char *src, void *fp)
+{
+    int ret = -1;
+    int res;
+
+    if (fp == NULL || src == NULL) {
+        return -1;
+    }
+
+    res = ocall_cc_fputs(&ret, src, strlen(src) + 1, (uint64_t)fp);
+    if (res != CC_SSL_SUCCESS || ret < 0) {
+        return -1;
+    }
+    return ret;
+}
 
 int sgx_print(const char *format, ...)
 {

--- a/Linux/sgx/libsgx_usgxssl/uunistd.cpp
+++ b/Linux/sgx/libsgx_usgxssl/uunistd.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2021 Intel Corporation. All rights reserved.
+ * Copyright (C) 2021 Intel Corporation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,60 +29,18 @@
  *
  */
 
-#include <string.h>
-
-#include "sgx_tsgxssl_t.h"
-#include "tcommon.h"
-#include "tSgxSSL_api.h"
-
-
-#ifndef SE_SIM
-
-// following definition is copied from common/inc/internal/se_cdefs.h
-
-#define SGX_ACCESS_VERSION(libname, num)                    \
-    extern "C" const char *sgx_##libname##_version;          \
-    const char * __attribute__((destructor)) libname##_access_version_dummy##num()      \
-    {                                                       \
-        return sgx_##libname##_version;                     \
-    } 
-
-
-// add a version to libsgx_tsgxssl
-SGX_ACCESS_VERSION(tssl, 1);
-
-#endif
-
-#define PATH_DEV_NULL				"/dev/null"
+#include <unistd.h>
 
 extern "C" {
 
-#define MAX_ENV_BUF_LEN 4096
-static __thread char t_env_buf[MAX_ENV_BUF_LEN];
-
-char *sgxssl_getenv(const char *name)
+int ocall_cc_read(int fd, void *buf, size_t buf_len)
 {
-    int ret = 0;
-    int res;
-    int buf_len = 0;
-    
-    if (t_env_buf == NULL || MAX_ENV_BUF_LEN <= 0) {
-        return NULL;
-    }
-   
-    memset(t_env_buf, 0, MAX_ENV_BUF_LEN);
-    res = ocall_cc_getenv(&ret, name, strlen(name), t_env_buf, MAX_ENV_BUF_LEN, &buf_len);
-    if (res != CC_SSL_SUCCESS || ret <= 0 || ret != buf_len) {
-        return NULL;
-    }
-    return t_env_buf;
+    return read(fd, buf, buf_len);
 }
 
-int sgxssl_atexit(void (*function)(void))
+int ocall_cc_write(int fd, const void *buf, size_t buf_len)
 {
-	// Do nothing, assuming that registered function does allocations cleanup.
-	// This should be fine, as sgx_destroy_enclave cleans everything inside of enclave.
-	return 0;
+    return write(fd, buf, buf_len);
 }
 
 }

--- a/Linux/sgx/test_app/enclave/tests/stdio_func.c
+++ b/Linux/sgx/test_app/enclave/tests/stdio_func.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2017 Intel Corporation. All rights reserved.
+ * Copyright (C) 2011-2021 Intel Corporation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -42,19 +42,3 @@ static int print_fp(const char *str, size_t len, void *fp)
     printf("%s", str);
     return 1;
 }
-
-void ERR_print_errors_fp(FILE *fp)
-{
-    ERR_print_errors_cb(print_fp, fp);
-}
-
-int BN_print_fp(FILE *fp, const BIGNUM *a)
-{
-    char* str = BN_bn2hex(a);
-    if (str == NULL)
-		return 0;
-	printf("%s", str);
-	OPENSSL_free(str);
-    return 1;
-}
-

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Intel® Software Guard Extensions SSL
 Introduction
 ------------
 The Intel® Software Guard Extensions SSL (Intel® SGX SSL) cryptographic library is intended to provide cryptographic services for Intel® Software Guard Extensions (SGX) enclave applications.
-The Intel® SGX SSL cryptographic library is based on the underlying OpenSSL* Open Source project, providing a full-strength general purpose cryptography library.
+The Intel® SGX SSL cryptographic library is based on the underlying OpenSSL* Open Source project, providing a full-strength general purpose cryptography library and providing a SSL protocol library for the Linux environment.
 Supported OpenSSL version is 1.1.1i. To work with 1.1.0 version please use "openssl_1.1.0" branch.
 
 In order to build Intel® SGX SSL libraries based on old OpenSSL version, checkout the tag with the corresponding versioning, e.g. lin_2.5_1.1.1c. Tag naming convention ``[lin/win]_<Intel(R) SGX SDK VERSION>_<OpenSSL VERSION>``.
@@ -59,7 +59,7 @@ To build Intel® SGX SSL package in Linux OS:
 ```
 make all test
 ```
-This will build and test the Intel® SGX SSL libraries (libsgx_tsgxssl.a, libsgx_usgxssl.a, libsgx_tsgxssl_crypto.a), which can be found in package/lib64/. And the Intel® SGX SSL trusted libraries (libsgx_tsgxssl.lib,  libsgx_tsgxssl_crypto.lib) with CVE-2020-0551 Mitigation enabled can be found in package/lib64/{cve_2020_0551_cf|cve_2020_0551_load}/.
+This will build and test the Intel® SGX SSL libraries (libsgx_tsgxssl.a, libsgx_usgxssl.a, libsgx_tsgxssl_crypto.a, libsgx_tsgxssl_ssl.a), which can be found in package/lib64/. And the Intel® SGX SSL trusted libraries (libsgx_tsgxssl.a,  libsgx_tsgxssl_crypto.a, libsgx_tsgxssl_ssl.a) with CVE-2020-0551 Mitigation enabled can be found in package/lib64/{cve_2020_0551_cf|cve_2020_0551_load}/.
 
 ### Available `make` flags:
 - DEBUG={1,0}: Libraries build mode, with debug symbols or without.

--- a/openssl_source/bypass_to_sgxssl.h
+++ b/openssl_source/bypass_to_sgxssl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2017 Intel Corporation. All rights reserved.
+ * Copyright (C) 2011-2021 Intel Corporation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -181,23 +181,19 @@
 #define mlock sgxssl_mlock
 #define madvise sgxssl_madvise
 
-/*
-#define fopen64 sgxssl_fopen64
 #define fopen sgxssl_fopen
-#define wfopen sgxssl_wfopen
 #define fclose sgxssl_fclose
 #define ferror sgxssl_ferror
 #define feof sgxssl_feof
 #define fflush sgxssl_fflush
 #define ftell sgxssl_ftell
 #define fseek sgxssl_fseek
-#define fread sgxssl_fread
 #define fwrite sgxssl_fwrite
-#define fgets sgxssl_fgets
 #define fputs sgxssl_fputs
-#define fileno sgxssl_fileno
 #define __fprintf_chk sgxssl_fprintf
-*/
+#define __vfprintf_chk sgxssl_vfprintf
+#define __fread_alias sgxssl_fread
+#define __fgets_alias sgxssl_fgets
 
 #if defined(SGXSDK_INT_VERSION) && (SGXSDK_INT_VERSION > 18)
 	#define _longjmp longjmp


### PR DESCRIPTION
Solution to issue ssl library is not supported #76 .

support ssl library by using ocall to supplement socket read/write and file operation.