### PR TITLE
Upgrade 1.1.1k

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Introduction
 ------------
 The Intel® Software Guard Extensions SSL (Intel® SGX SSL) cryptographic library is intended to provide cryptographic services for Intel® Software Guard Extensions (SGX) enclave applications.
 The Intel® SGX SSL cryptographic library is based on the underlying OpenSSL* Open Source project, providing a full-strength general purpose cryptography library.
-Supported OpenSSL version is 1.1.1i. To work with 1.1.0 version please use "openssl_1.1.0" branch.
+Supported OpenSSL version is 1.1.1k. To work with 1.1.0 version please use "openssl_1.1.0" branch.
 
 In order to build Intel® SGX SSL libraries based on old OpenSSL version, checkout the tag with the corresponding versioning, e.g. lin_2.5_1.1.1c. Tag naming convention ``[lin/win]_<Intel(R) SGX SDK VERSION>_<OpenSSL VERSION>``.
 
@@ -36,7 +36,7 @@ Windows
  (Note: 7-Zip, Perl, NASM need to be included in machine's PATH variable)
 
 To build Intel® SGX SSL package in Windows OS:
-1. Download OpenSSL package into openssl_source/ directory. (tar.gz package, e.g. openssl-1.1.1i.tar.gz)
+1. Download OpenSSL package into openssl_source/ directory. (tar.gz package, e.g. openssl-1.1.1k.tar.gz)
 2. Download and install latest SGX SDK from [Intel Developer Zone](https://software.intel.com/en-us/sgx-sdk/download). You can find installation guide from the same website.
 3. Change the directory to the SGXSSL path and enter the following command:
 ```
@@ -52,7 +52,7 @@ Linux
 - Intel(R) SGX Linux latest release, including SDK, PSW, and driver
 
 To build Intel® SGX SSL package in Linux OS:
-1. Download OpenSSL 1.1.1i package into openssl_source/ directory. (tar.gz package, e.g. openssl-1.1.1i.tar.gz)
+1. Download OpenSSL 1.1.1k package into openssl_source/ directory. (tar.gz package, e.g. openssl-1.1.1k.tar.gz)
 2. Download and install latest SGX SDK from [01.org](https://01.org/intel-software-guard-extensions/downloads). You can find installation guide in the same website.
 3. Source SGX SDK's environment variables.
 4. Cd to Linux/ directory and run:

--- a/openssl_source/rand_lib.c
+++ b/openssl_source/rand_lib.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2020 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2021 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -432,9 +432,13 @@ err:
 RAND_POOL *rand_pool_new(int entropy_requested, int secure,
                          size_t min_len, size_t max_len)
 {
-    RAND_POOL *pool = OPENSSL_zalloc(sizeof(*pool));
+    RAND_POOL *pool;
     size_t min_alloc_size = RAND_POOL_MIN_ALLOCATION(secure);
 
+    if (!RUN_ONCE(&rand_init, do_rand_init))
+        return NULL;
+
+    pool = OPENSSL_zalloc(sizeof(*pool));
     if (pool == NULL) {
         RANDerr(RAND_F_RAND_POOL_NEW, ERR_R_MALLOC_FAILURE);
         return NULL;


### PR DESCRIPTION
SGXSSL will take OpenSSL 1.1.1k source code. No LVI mitigation patch necessary since no assembly script or template was changed for X86_64 configuration, either Linux or Windows.