### PR TITLE
add a quick check of LVI mitigation tool

### DIFF
--- a/Linux/Makefile
+++ b/Linux/Makefile
@@ -31,16 +31,17 @@
 include buildenv.mk
 include sgx/buildenv.mk
 LINUX_SGX_BUILD ?= 0
-EMPTY_SRC = check_lvi_toolset.cpp
+EMPTY_SRC = check_lvi_toolset
 .PHONY: sgxssl sgxssl_no_mitigation clean install uninstall
 
 
 all: sgxssl
 
 sgxssl:
-	@rm -rf $(EMPTY_SRC) && touch $(EMPTY_SRC)
-	@gcc -Wa,-mlfence-after-load=yes -c $(EMPTY_SRC) 2> /dev/null \
+	@rm -rf $(EMPTY_SRC).* && touch $(EMPTY_SRC).cpp
+	@gcc -Wa,-mlfence-after-load=yes -c $(EMPTY_SRC).cpp 2> /dev/null \
 		|| (echo "Please follow the instruction at https://github.com/intel/linux-sgx/blob/master/README.md#build-the-intelr-sgx-sdk-and-intelr-sgx-psw-package to install \"mitigation tools\" first."  &&  exit 1)
+	@rm -rf $(EMPTY_SRC).*
 	$(MAKE) -C sgx/ clean
 	$(MAKE) -C sgx/ MITIGATION-CVE-2020-0551=LOAD
 	$(MAKE) -C sgx/ clean

--- a/Linux/Makefile
+++ b/Linux/Makefile
@@ -31,13 +31,16 @@
 include buildenv.mk
 include sgx/buildenv.mk
 LINUX_SGX_BUILD ?= 0
-
+EMPTY_SRC = check_lvi_toolset.cpp
 .PHONY: sgxssl sgxssl_no_mitigation clean install uninstall
 
 
 all: sgxssl
 
 sgxssl:
+	@rm -rf $(EMPTY_SRC) && touch $(EMPTY_SRC)
+	@gcc -Wa,-mlfence-after-load=yes -c $(EMPTY_SRC) 2> /dev/null \
+		|| (echo "Please follow the instruction at https://github.com/intel/linux-sgx/blob/master/README.md#build-the-intelr-sgx-sdk-and-intelr-sgx-psw-package to install \"mitigation tools\" first."  &&  exit 1)
 	$(MAKE) -C sgx/ clean
 	$(MAKE) -C sgx/ MITIGATION-CVE-2020-0551=LOAD
 	$(MAKE) -C sgx/ clean


### PR DESCRIPTION
To avoid the user reporting issues for the same reason, such as https://github.com/intel/intel-sgx-ssl/issues/78, https://github.com/intel/intel-sgx-ssl/issues/64, and https://github.com/intel/intel-sgx-ssl/issues/57, even it has been described in the https://github.com/intel/intel-sgx-ssl/blob/master/README.md. 