### PR TITLE
use pthread_self and pthread_equal from SGX SDK

### DIFF
--- a/Linux/sgx/libsgx_tsgxssl/tpthread.cpp
+++ b/Linux/sgx/libsgx_tsgxssl/tpthread.cpp
@@ -278,17 +278,6 @@ int sgxssl_pthread_setspecific (pthread_key_t key, const void *data)
 	return 0;
 }
 
-pthread_t sgxssl_pthread_self (void)
-{
-	FSTART;
-
-	sgx_thread_t thread_self = sgx_thread_self();
-
-	FEND;
-
-	return thread_self;
-}
-
 //Thread forking isn't supported inside enclave.
 int sgxssl_pthread_atfork(void (*prepare)(void), void (*parent)(void), void (*child)(void))
 {
@@ -298,21 +287,6 @@ int sgxssl_pthread_atfork(void (*prepare)(void), void (*parent)(void), void (*ch
     FEND;
     //Operation not permitted
     return EPERM;
-}
-
-// Return 0 if the threads are not equal
-int sgxssl_pthread_equal (pthread_t thread1, pthread_t thread2)
-{
-	FSTART;
-	
-	int retval = FALSE;
-
-	if (thread1 == thread2)
-		retval = TRUE;
-
-	FEND;
-
-	return retval;
 }
 
 }

--- a/Linux/sgx/test_app/enclave/TestEnclave.edl
+++ b/Linux/sgx/test_app/enclave/TestEnclave.edl
@@ -34,7 +34,7 @@
 enclave {
     
 from "sgx_tsgxssl.edl" import *;
-
+from "sgx_pthread.edl" import *;
     /* 
      * uprint - invokes OCALL to display string buffer inside the enclave.
      *  [in]: copy the string buffer to App outside.

--- a/openssl_source/bypass_to_sgxssl.h
+++ b/openssl_source/bypass_to_sgxssl.h
@@ -255,8 +255,6 @@ char * sgxssl___builtin___strcpy_chk(char *dest, const char *src, unsigned int d
 #define pthread_setspecific sgxssl_pthread_setspecific
 #define pthread_getspecific sgxssl_pthread_getspecific
 #define pthread_key_delete sgxssl_pthread_key_delete
-#define pthread_self sgxssl_pthread_self
-#define pthread_equal sgxssl_pthread_equal
 
 #define __ctype_b_loc sgxssl___ctype_b_loc
 #define __ctype_tolower_loc sgxssl___ctype_tolower_loc


### PR DESCRIPTION
Use pthread_self and pthread_equal from SGX SDK, instead of the bypass definitions.
Some other pthead functions like pthread_create_once will be changed later.

