### PR TITLE
Enable no threads in build

### DIFF
--- a/Linux/build_openssl.sh
+++ b/Linux/build_openssl.sh
@@ -74,6 +74,10 @@ if [[ $# -gt 0 ]] && [[ $1 == "debug" || $2 == "debug" || $3 == "debug" || $4 ==
     ADDITIONAL_CONF="-g "
 fi
 
+if [[ $# -gt 0 ]] && [[ $1 == "no-threads" || $2 == "no-threads" || $3 == "no-threads" || $4 == "no-threads" ]] ; then
+	ADDITIONAL_CONF+="no-threads"
+fi
+
 # Mitigation flags
 MITIGATION_OPT=""
 MITIGATION_FLAGS=""
@@ -132,7 +136,7 @@ cp sgx_config.conf $OPENSSL_VERSION/ || exit 1
 cp x86_64-xlate.pl $OPENSSL_VERSION/crypto/perlasm/ || exit 1
 
 cd $SGXSSL_ROOT/../openssl_source/$OPENSSL_VERSION || exit 1
-perl Configure --config=sgx_config.conf sgx-linux-x86_64 --with-rand-seed=none $ADDITIONAL_CONF $SPACE_OPT $MITIGATION_FLAGS no-idea no-mdc2 no-rc5 no-rc4 no-bf no-ec2m no-camellia no-cast no-srp no-hw no-dso no-shared no-ssl3 no-md2 no-md4 no-ui no-stdio no-afalgeng -D_FORTIFY_SOURCE=2 -DGETPID_IS_MEANINGLESS -include$SGXSSL_ROOT/../openssl_source/bypass_to_sgxssl.h --prefix=$OPENSSL_INSTALL_DIR || exit 1
+perl Configure --config=sgx_config.conf sgx-linux-x86_64 --with-rand-seed=none $ADDITIONAL_CONF $SPACE_OPT $MITIGATION_FLAGS no-idea no-mdc2 no-rc5 no-rc4 no-bf no-ec2m no-camellia no-cast no-srp no-hw no-dso no-shared no-ssl3 no-md2 no-md4 no-ui-console no-stdio no-afalgeng -D_FORTIFY_SOURCE=2 -DGETPID_IS_MEANINGLESS -include$SGXSSL_ROOT/../openssl_source/bypass_to_sgxssl.h --prefix=$OPENSSL_INSTALL_DIR || exit 1
 
 make build_all_generated || exit 1
 

--- a/Linux/build_openssl.sh
+++ b/Linux/build_openssl.sh
@@ -76,6 +76,7 @@ fi
 
 if [[ $# -gt 0 ]] && [[ $1 == "no-threads" || $2 == "no-threads" || $3 == "no-threads" || $4 == "no-threads" ]] ; then
 	ADDITIONAL_CONF+="no-threads"
+	sed -i 's/static __thread/static/' $SGXSSL_ROOT/sgx/libsgx_tsgxssl/bionic_localtime.c
 fi
 
 # Mitigation flags

--- a/Linux/build_openssl.sh
+++ b/Linux/build_openssl.sh
@@ -62,19 +62,19 @@ sed -i '/BSAES_ASM/d' $OPENSSL_VERSION/Configure
 
 ##Space optimization flags.
 SPACE_OPT=
-if [[ $# -gt 0 ]] && [[ $1 == "space-opt" || $2 == "space-opt" || $3 == "space-opt" || $4 == "space-opt" ]] ; then
+if [[ "$*" == *"space-opt"* ]] ; then
 SPACE_OPT="-fno-tree-vectorize no-autoalginit -fno-asynchronous-unwind-tables no-cms no-dsa -DOPENSSL_assert=  no-filenames no-rdrand -DOPENSSL_SMALL_FOOTPRINT no-err -fdata-sections -ffunction-sections -Os -Wl,--gc-sections"
 sed -i "/# define OPENSSL_assert/d" $OPENSSL_VERSION/include/openssl/crypto.h
 sed -i '/OPENSSL_die("assertion failed/d' $OPENSSL_VERSION/include/openssl/crypto.h
 fi
 
 OUTPUT_LIB=libsgx_tsgxssl_crypto.a
-if [[ $# -gt 0 ]] && [[ $1 == "debug" || $2 == "debug" || $3 == "debug" || $4 == "debug" ]] ; then
+if [[ "$*" == *"debug"* ]] ; then
 	OUTPUT_LIB=libsgx_tsgxssl_cryptod.a
     ADDITIONAL_CONF="-g "
 fi
 
-if [[ $# -gt 0 ]] && [[ $1 == "no-threads" || $2 == "no-threads" || $3 == "no-threads" || $4 == "no-threads" ]] ; then
+if [[ "$*" == *"no-threads"* ]] ; then
 	ADDITIONAL_CONF+="no-threads"
 fi
 

--- a/Linux/build_openssl.sh
+++ b/Linux/build_openssl.sh
@@ -76,7 +76,6 @@ fi
 
 if [[ $# -gt 0 ]] && [[ $1 == "no-threads" || $2 == "no-threads" || $3 == "no-threads" || $4 == "no-threads" ]] ; then
 	ADDITIONAL_CONF+="no-threads"
-	sed -i 's/static __thread/static/' $SGXSSL_ROOT/sgx/libsgx_tsgxssl/bionic_localtime.c
 fi
 
 # Mitigation flags

--- a/Linux/sgx/Makefile
+++ b/Linux/sgx/Makefile
@@ -54,7 +54,9 @@ all: $(PACKAGE_LIB)/$(OPENSSL_LIB)
 	$(MAKE) -C $(UNTRUSTED_LIB_DIR) all
 
 ifeq ($(LINUX_SGX_BUILD), 0)
+ifneq ($(NO_THREADS), 1)
 	$(MAKE) -C $(TEST_DIR) all
+endif
 endif
 
 ifneq ($(MITIGATION-CVE-2020-0551),)

--- a/Linux/sgx/Makefile
+++ b/Linux/sgx/Makefile
@@ -46,6 +46,7 @@ endif
 
 ifeq ($(NO_THREADS), 1)
         OPENSSL_CONFIG += no-threads
+	export NO_THREADS_CFLAG = -DNO_THREADS
 endif
 
 all: $(PACKAGE_LIB)/$(OPENSSL_LIB)

--- a/Linux/sgx/Makefile
+++ b/Linux/sgx/Makefile
@@ -44,6 +44,10 @@ ifeq ($(DEBUG), 1)
 	OPENSSL_CONFIG += debug
 endif
 
+ifeq ($(NO_THREADS), 1)
+        OPENSSL_CONFIG += no-threads
+endif
+
 all: $(PACKAGE_LIB)/$(OPENSSL_LIB)
 	$(MAKE) -C $(TRUSTED_LIB_DIR) all
 	$(MAKE) -C $(UNTRUSTED_LIB_DIR) all

--- a/Linux/sgx/libsgx_tsgxssl/Makefile
+++ b/Linux/sgx/libsgx_tsgxssl/Makefile
@@ -91,7 +91,7 @@ Sgx_tssl_S_Objects := $(addprefix $(OBJDIR)/, $(Sgx_tssl_S_Files:.S=.o))
 Sgx_tssl_Include_Paths := -I. -I$(PACKAGE_INC) -I$(SGX_SDK_INC) -I$(SGX_SDK_INC)/tlibc -I$(LIBCXX_INC)
 
 Common_C_Cpp_Flags := -DOS_ID=$(OS_ID) $(SGX_COMMON_CFLAGS) -nostdinc -fdata-sections -ffunction-sections -Os -Wl,--gc-sections -fvisibility=hidden -fpie -fpic -fstack-protector -fno-builtin-printf -Wformat -Wformat-security $(Sgx_tssl_Include_Paths)
-Sgx_tssl_C_Flags := $(Common_C_Cpp_Flags) -Wno-implicit-function-declaration -std=c11 $(MITIGATION_CFLAGS)
+Sgx_tssl_C_Flags := $(Common_C_Cpp_Flags) -Wno-implicit-function-declaration -std=c11 $(MITIGATION_CFLAGS) $(NO_THREADS_CFLAG)
 Sgx_tssl_Cpp_Flags := $(Common_C_Cpp_Flags) -std=c++11 -nostdinc++ $(MITIGATION_CFLAGS)
 $(shell mkdir -p $(OBJDIR))
 

--- a/Linux/sgx/libsgx_tsgxssl/bionic_localtime.c
+++ b/Linux/sgx/libsgx_tsgxssl/bionic_localtime.c
@@ -214,8 +214,11 @@ timesub(const time_t *const timep, const int_fast32_t offset,
 	return tmp;
 }
 
-
+#if defined(NO_THREADS)
+static struct tm g_tm;
+#else
 static __thread struct tm g_tm;
+#endif
 
 struct tm* sgxssl_gmtime_r(const time_t* timep, struct tm *result)
 {

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ This will build and test the Intel® SGX SSL libraries (libsgx_tsgxssl.a, libsgx
 - SGX_MODE={HW,SIM}: SGX feature mode. Hardware/Simulation
 - DESTDIR=\<PATH\>: Directory realpath to install Intel® SGX SSL libraries in. Default /opt/intel/sgxssl/
 - VERBOSE={1,0}: Makefile verbose mode. Print compilation commands before executing it.
+- NO_THREADS={1,0}: Enable "no-threads" in the OpenSSL's build configuration options
 
 To install Intel® SGX SSL libraries in Linux OS, run:
 ```

--- a/openssl_source/bypass_to_sgxssl.h
+++ b/openssl_source/bypass_to_sgxssl.h
@@ -235,6 +235,7 @@ char * sgxssl___builtin___strcpy_chk(char *dest, const char *src, unsigned int d
 
 #define time sgxssl_time
 #define gmtime_r sgxssl_gmtime_r
+#define gmtime sgxssl_gmtime
 #define gettimeofday sgxssl_gettimeofday
 
 //openssl 1.1.1 new APIs


### PR DESCRIPTION
Enable  build configure no-threads from OpenSSL in SGX SSL, with a flag "NO_THREADS"