### PR TITLE
correct version numbers and fix typos

### DIFF
--- a/Linux/sgx/libsgx_tsgxssl/tsgxssl_version.cpp
+++ b/Linux/sgx/libsgx_tsgxssl/tsgxssl_version.cpp
@@ -29,8 +29,8 @@
  *
  */
 
-// This srting should be updated before every release!!
-#define STRFILEVER "1.1.0"
+// This string should be updated before every release!!
+#define STRFILEVER "1.1.1"
 
 #define __CONCAT(x, y) x/**/y
 

--- a/Linux/sgx/libsgx_usgxssl/usgxssl_version.cpp
+++ b/Linux/sgx/libsgx_usgxssl/usgxssl_version.cpp
@@ -29,8 +29,8 @@
  *
  */
 
-// This srting should be updated before every release!!
-#define STRFILEVER "1.1.0"
+// This string should be updated before every release!!
+#define STRFILEVER "1.1.1"
 
 #define __CONCAT(x, y) x/**/y
 


### PR DESCRIPTION
The libsgx_usgxssl.a and libsgx_usgxssl.a will have a correct version number:
 SGX_TSSL_VERSION_1.1.1
 SGX_USSL_VERSION_1.1.1