### PR TITLE
bug_fix_cbc_smx_sample_xiaonanINTC

### DIFF
--- a/Linux/sgx/test_app/enclave/tests/evp_smx.c
+++ b/Linux/sgx/test_app/enclave/tests/evp_smx.c
@@ -463,6 +463,7 @@ int ecall_sm4_cbc(void)
 
     int len = 0;
     EVP_CIPHER_CTX* evp_ctx = NULL;
+    int pad = 0;
     int ret = 0;
 
     do { 
@@ -479,32 +480,37 @@ int ecall_sm4_cbc(void)
             ret = -2;
             break;
         }
+        if (EVP_CIPHER_CTX_set_padding(evp_ctx, pad) != 1) {
+            printf("Error: fail to set padding\n");
+            ret = -3;
+            break;
+		}
 
         // 3. Encrypt the plaintext and obtain the encrypted output
         if (EVP_EncryptUpdate(evp_ctx, encryptedText, &len, plainText, sizeof(plainText)) != 1) {
             printf("Error: fail to encrypt the plaintext\n");
-            ret = -3;
+            ret = -4;
             break;
         }
 
         // 4. Finalize the encryption
         if (EVP_EncryptFinal_ex(evp_ctx, encryptedText + len, &len) != 1) {
             printf("Error: fail to finalize the encryption\n");
-            ret = -4;
+            ret = -5;
             break;
         }
 
         // 5. Initialize decrypt, key and IV
         if (!EVP_DecryptInit_ex(evp_ctx, EVP_sm4_cbc(), NULL, (unsigned char*)key, iv)) {
             printf("Error: fail to initialize decrypt, key and IV\n");
-            ret = -5;
+            ret = -6;
             break;
         }
 
         // 6. Decrypt the ciphertext and obtain the decrypted output
         if (!EVP_DecryptUpdate(evp_ctx, decryptedText, &len, encryptedText, sizeof(encryptedText))) {
             printf("Error: fail to decrypt the ciphertext\n");
-            ret = -6;
+            ret = -7;
             break;
         }
 
@@ -515,7 +521,7 @@ int ecall_sm4_cbc(void)
         if (sizeof(decryptedText) % 16 != 0) {
             if (EVP_DecryptFinal_ex(evp_ctx, decryptedText + len, &len) <= 0) {
                 printf("Error: fail to finalize the decryption\n");
-                ret = -7;
+                ret = -8;
                 break;
             }
         }
@@ -523,7 +529,7 @@ int ecall_sm4_cbc(void)
         // 8. Compare original and decrypted text
         if (memcmp(plainText, decryptedText, sizeof(plainText)) != 0) {
             printf("Error: original and decrypted text is different\n");
-            ret = -8;
+            ret = -9;
             break;
         }
 


### PR DESCRIPTION
Issues: here is a test failure of SM4 CBC due to padding, the plaintext is 16 bytes, after PKCS7 padding, there will be one more block (0x10*16) to be ecrypted. 
Solution: add int pad = 0; EVP_CIPHER_CTX_set_padding(evp_ctx, pad); after EVP_EncryptInit_ex().