### PR TITLE
fix build problem for no-threads

### DIFF
--- a/Linux/sgx/test_app/Makefile
+++ b/Linux/sgx/test_app/Makefile
@@ -34,7 +34,7 @@ all:
 	$(MAKE) -f sgx_u.mk LINUX_SGX_BUILD=$(LINUX_SGX_BUILD) all
 	$(MAKE) -f sgx_t.mk LINUX_SGX_BUILD=$(LINUX_SGX_BUILD) all
 
-test:
+test: all
 	$(MAKE) -f sgx_u.mk test
 
 clean:

--- a/Linux/sgx/test_app/enclave/tests/threadstest.c
+++ b/Linux/sgx/test_app/enclave/tests/threadstest.c
@@ -82,31 +82,6 @@ static int wait_for_thread(thread_t thread)
 	return 1;
 }
 
-#elif defined(OPENSSL_SYS_WINDOWS)
-
-typedef HANDLE thread_t;
-
-static DWORD WINAPI thread_run(LPVOID arg)
-{
-    void (*f)(void);
-
-    *(void **) (&f) = arg;
-
-    f();
-    return 0;
-}
-
-static int run_thread(thread_t *t, void (*f)(void))
-{
-    *t = CreateThread(NULL, 0, thread_run, *(void **) &f, 0, NULL);
-    return *t != NULL;
-}
-
-static int wait_for_thread(thread_t thread)
-{
-    return WaitForSingleObject(thread, INFINITE) == 0;
-}
-
 #else
 
 typedef pthread_t thread_t;


### PR DESCRIPTION
Fix the build problem in thread test of the test sample, when no-threads is enabled. Related commit https://github.com/intel/intel-sgx-ssl/commit/77704ffebb0e669a821c03d1263b3186c150532c.

Tested with `NO_THREADS=1 make all test` and  `make all test`