### PR TITLE
remove SGXSSL ftime definition for Linux

### DIFF
--- a/Linux/package/include/sgx_tsgxssl.edl
+++ b/Linux/package/include/sgx_tsgxssl.edl
@@ -36,10 +36,8 @@ enclave {
     from "sgx_tstdc.edl" import *;
     
     untrusted {
-    	 void u_sgxssl_ftime([out, size=timeb_len] void * timeptr, uint32_t timeb_len);
     };
 
     trusted {
-
     };
 };

--- a/Linux/sgx/libsgx_usgxssl/utime.cpp
+++ b/Linux/sgx/libsgx_usgxssl/utime.cpp
@@ -51,14 +51,3 @@ SGX_ACCESS_VERSION(ussl, 1);
 
 #endif
 
-extern "C" {
-
-void u_sgxssl_ftime(void * timeptr, uint32_t timeb_len)
-{
-	SGX_ASSERT_STRUCT_SIZE(struct timeb, timeb_len);
-
-	ftime((struct timeb *) timeptr);
-
-}
-
-}


### PR DESCRIPTION
It seems not called by any code