### PR TITLE
Add no buildtest option

### DIFF
--- a/Linux/sgx/Makefile
+++ b/Linux/sgx/Makefile
@@ -55,7 +55,9 @@ all: $(PACKAGE_LIB)/$(OPENSSL_LIB)
 
 ifeq ($(LINUX_SGX_BUILD), 0)
 ifneq ($(NO_THREADS), 1)
+ifneq ($(NO_BUILDTEST), 1)
 	$(MAKE) -C $(TEST_DIR) all
+endif
 endif
 endif
 

--- a/Linux/sgx/Makefile
+++ b/Linux/sgx/Makefile
@@ -50,12 +50,14 @@ ifeq ($(NO_THREADS), 1)
 endif
 
 all: $(PACKAGE_LIB)/$(OPENSSL_LIB)
+ifneq ($(CRYPTO_ONLY), 1)
 	$(MAKE) -C $(TRUSTED_LIB_DIR) all
 	$(MAKE) -C $(UNTRUSTED_LIB_DIR) all
+endif
 
 ifeq ($(LINUX_SGX_BUILD), 0)
 ifneq ($(NO_THREADS), 1)
-ifneq ($(NO_BUILDTEST), 1)
+ifneq ($(CRYPTO_ONLY), 1)
 	$(MAKE) -C $(TEST_DIR) all
 endif
 endif
@@ -66,7 +68,9 @@ ifneq ($(MITIGATION-CVE-2020-0551),)
 	$(RM) -r $(PACKAGE_LIB)$(MITIGATION_LIB_PATH)/$(OPENSSL_LIB)
 	mkdir -p $(PACKAGE_LIB)$(MITIGATION_LIB_PATH)
 	mv $(PACKAGE_LIB)/$(OPENSSL_LIB) $(PACKAGE_LIB)$(MITIGATION_LIB_PATH)/
+ifneq ($(CRYPTO_ONLY), 1)
 	mv $(PACKAGE_LIB)/$(TRUSTED_LIB) $(PACKAGE_LIB)$(MITIGATION_LIB_PATH)/
+endif
 endif
 
 $(PACKAGE_LIB)/$(OPENSSL_LIB):

--- a/Linux/sgx/Makefile
+++ b/Linux/sgx/Makefile
@@ -53,11 +53,9 @@ all: $(PACKAGE_LIB)/$(OPENSSL_LIB)
 ifneq ($(CRYPTO_ONLY), 1)
 	$(MAKE) -C $(TRUSTED_LIB_DIR) all
 	$(MAKE) -C $(UNTRUSTED_LIB_DIR) all
-endif
 
 ifeq ($(LINUX_SGX_BUILD), 0)
 ifneq ($(NO_THREADS), 1)
-ifneq ($(CRYPTO_ONLY), 1)
 	$(MAKE) -C $(TEST_DIR) all
 endif
 endif

--- a/Windows/build_package.cmd
+++ b/Windows/build_package.cmd
@@ -171,7 +171,7 @@ xcopy /y include\crypto\* %SGXSSL_ROOT%\package\include\crypto\
 
 echo "Done building OpenSSL for %my_Platform% | %my_Configuration%. Building Intel® Software Guard Extensions SSL libraries  %date% %time%"
 
-if "%TEST_MODE%" equ "NOTEST" (
+if "%TEST_MODE%" equ "CRYPTO_ONLY" (
 goto end
 )
 

--- a/Windows/build_package.cmd
+++ b/Windows/build_package.cmd
@@ -170,6 +170,11 @@ xcopy /y include\openssl\* %SGXSSL_ROOT%\package\include\openssl\
 xcopy /y include\crypto\* %SGXSSL_ROOT%\package\include\crypto\
 
 echo "Done building OpenSSL for %my_Platform% | %my_Configuration%. Building Intel® Software Guard Extensions SSL libraries  %date% %time%"
+
+if "%TEST_MODE%" equ "NOTEST" (
+goto end
+)
+
 cd %SGXSSL_SOLUTION%\
 
  


### PR DESCRIPTION
make it possible to skip building unit test
Linux:
`CRYPTO_ONLY=1 make`
Windows(internal usage):
`build_package.cmd Platform_Configuration OpenSSL_Version no-clean CRYPTO_ONLY`

