### PR TITLE
add scripts in powershell for Windows build

### DIFF
--- a/Windows/build.ps1
+++ b/Windows/build.ps1
@@ -1,0 +1,113 @@
+#
+# Copyright (C) 2011-2023 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+
+
+#=========================================#
+# Do not edit this script below this line #
+#=========================================#
+
+Param(
+	[Parameter(mandatory=$false)][string]$OPENSSL_VERSION = "openssl-3.0.0",
+    [Parameter(mandatory=$false)][bool] $PSW_available=1
+)
+function ExecuteCommand() {
+    param
+    (
+        [Parameter(Mandatory=$true)][string] $Command,
+        [Parameter(Mandatory=$true)][string] $Cmdarg
+    )
+    try {
+        & $command $cmdarg
+        if ($LASTEXITCODE -ne 0) {
+            throw 'Execution failed'
+            Exit 1
+        }
+    } catch {
+        Write-Error "cannot find $command"
+        Exit 1
+    }
+}
+
+try {
+    #Write-out "Validating Prerequisites (perl, nasm)"
+    ExecuteCommand "nasm" "-v"
+    ExecuteCommand "perl" "-v"
+} catch {
+    Write-Error "cannot find nasm or perl, exiting"
+    Exit 1
+}
+
+try {
+    $SGXSSL_ROOT = Get-Location
+    if (-not (Test-Path "../openssl_source/$OpenSSL_version.tar.gz" -PathType Leaf))
+    {
+        Write-Output "$OpenSSL_version source code package not available, exiting"
+        Exit 1 
+    }
+    Write-Output "Building SGXSSL with: $OpenSSL_version"
+    ForEach ($Config in ("debug", "release", "cve-2020-0551-load-release", "cve-2020-0551-cf-release")) {
+        Write-Output "  Building libraries in x64, $Config..."
+        $BUILD_LEVEL = "ALL"
+        if ( $PSW_available -ne 1)
+        {
+            $BUILD_LEVEL = "SKIP_TEST"
+        }
+        $Build_proc = Start-Process powershell -ArgumentList ".\build_pkg.ps1 -my_Configuration $Config -OPENSSL_version $OpenSSL_version -BUILD_LEVEL $BUILD_LEVEL -Clean 0" -PassThru
+        $Build_proc.WaitForExit()
+        if ($Build_proc.HasExited) {
+            # Write-Host "The build process has exited."
+        }
+        if ($Build_proc.ExitCode  -ne 0) {
+            Write-Output "  Failed building config $Config, exiting..."
+            Exit 1
+        } else {
+            Write-Output "  Successfully built config $Config"
+        }
+    }
+
+    $currentTime = Get-Date -format "dd-MMM-yyyy HH:mm:ss"
+    Write-Output "Build completed: Zipping package $currentTime"
+    $SGXSSL_version_numbers = ($OpenSSL_version -split '-')[1]
+    if ( $PSW_available -eq 1) 
+    {
+        $SGXSSL_version_numbers = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Intel\SGX_PSW" -Name "Version")."Version" + "_" + $SGXSSL_version_numbers
+    }
+    Set-Location package
+    Compress-Archive -Path docs, include, lib  -DestinationPath ..\sgxssl.$SGXSSL_version_numbers.zip -Update
+    
+} catch {
+    Write-Output $_.ToString()
+    Write-Output $_.ScriptStackTrace
+    Exit 1
+} finally  {
+    set-location $SGXSSL_ROOT
+}
+Exit 0

--- a/Windows/build_pkg.ps1
+++ b/Windows/build_pkg.ps1
@@ -1,0 +1,156 @@
+#
+# Copyright (C) 2011-2023 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+
+
+#=========================================#
+# Do not edit this script below this line #
+#=========================================#
+
+Param(
+	[string]$Platform = "x64",
+    [string]$VS_CMD_PLFM = "amd64",
+    [string]$OPENSSL_CFG_PLFM ="sgx-VC-WIN64A",
+    [Parameter(mandatory=$true)][string]$my_Configuration,
+    [Parameter(mandatory=$false)][string]$OPENSSL_VERSION = "openssl-3.0.0",
+    [Parameter(mandatory=$false)][bool] $Clean = 0,
+    [Parameter(mandatory=$false)][string] $BUILD_LEVEL ="",
+    [Parameter(mandatory=$false)][bool] $Pause_at_end = 0    
+)
+
+function Invoke-Environment {
+    param
+    (
+        # Any cmd shell command, normally a configuration batch file.
+        [Parameter(Mandatory=$true)][string] $Command
+    )
+    $Command = "`"" + $Command + "`""
+    cmd /c "$Command > nul 2>&1 && set" | . { process {
+        if ($_ -match '^([^=]+)=(.*)') {
+            [System.Environment]::SetEnvironmentVariable($matches[1], $matches[2])
+        }
+    }}
+}
+
+try {
+    Write-Output "Don't close this Window. Building SGXSSL in $my_Configuration config... "
+    $SGXSSL_ROOT = Get-Location
+    perl svn_revision.pl > sgx\libsgx_tsgxssl\tsgxssl_version.h
+    Set-Location ..\openssl_source
+    if (Test-Path $OPENSSL_VERSION -PathType Container)
+    {
+        Remove-Item $OPENSSL_VERSION -Recurse -Force
+    }
+    tar -xf "$OPENSSL_VERSION.tar.gz"
+    (get-content $OPENSSL_VERSION\Configure) -replace ('BSAES_ASM','') | out-file $OPENSSL_VERSION\Configure
+    Copy-Item rand_lib.c $OPENSSL_VERSION\crypto\rand\
+    Copy-Item sgx_config.conf $OPENSSL_VERSION\
+    Copy-Item x86_64-xlate.pl $OPENSSL_VERSION\crypto\perlasm
+    Copy-Item threads_win.c $OPENSSL_VERSION\crypto\
+
+    if ($my_Configuration -eq "cve-2020-0551-load-release")
+    {
+        Copy-Item Windows\crypto\* $OPENSSL_VERSION\crypto -Force -Recurse
+    }
+
+    if ($my_Configuration -eq "cve-2020-0551-cf-release")
+    {
+    }
+
+    Set-Location $OPENSSL_VERSION
+    Copy-Item  $Env:SGXSDKInstallPath\scripts\sgx-asm-pp.py .
+    
+    if ($my_Configuration -eq "debug")
+    {
+        $OPENSSL_CFG_PLFM += " --debug"
+    }
+
+    $CVE_2020_0551_MITIGATIONS= ""
+    if ($my_Configuration -eq "cve-2020-0551-cf-release")
+    {
+        $CVE_2020_0551_MITIGATIONS = "-Qspectre-load-cf"
+    } elseif ($my_Configuration -eq "cve-2020-0551-load-release")
+    {
+        $CVE_2020_0551_MITIGATIONS = "-Qspectre-load"
+    }
+
+    $ADDITIONAL_CONF = ""
+    if ( $Env:OSSL3ONLY -eq "1" )
+    {
+        $ADDITIONAL_CONF= "--api\=3.0 no-deprecated"
+    }
+
+    $Perl_config_proc = Start-Process perl -ArgumentList "Configure --config=sgx_config.conf $OPENSSL_CFG_PLFM  $CVE_2020_0551_MITIGATIONS $ADDITIONAL_CONF no-dtls no-idea no-mdc2 no-rc5 no-rc4 no-bf no-ec2m no-camellia no-cast no-srp no-padlockeng no-dso no-shared no-ui-console no-ssl3 no-md2 no-md4 no-stdio -FI$SGXSSL_ROOT\..\openssl_source\bypass_to_sgxssl.h -D_NO_CRT_STDIO_INLINE -DOPENSSL_NO_SOCK -DOPENSSL_NO_DGRAM -DOPENSSL_NO_ASYNC " -wait -PassThru
+    if ($Perl_config_proc.ExitCode  -ne 0) {
+        Write-Output "  Failed configuring OpenSSL code, exiting..."
+        Exit 1
+    } else {
+        Write-Output "  Successfully configured OpenSSL code"
+    }
+    (Get-Content crypto\engine\tb_rand.c) |  Foreach-Object {$_ -replace 'ENGINE_set_default_RAND', 'dummy_ENGINE_set_default_RAND'} | Out-File crypto\engine\tb_rand.c
+    Invoke-Environment "C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Auxiliary\Build\vcvars64.bat"
+    nmake build_generated libcrypto.lib
+
+    New-Item -Path $SGXSSL_ROOT\package\lib\$Platform\$my_Configuration -ItemType Directory -Force
+    Copy-Item  libcrypto.lib $SGXSSL_ROOT\package\lib\$Platform\$my_Configuration\libsgx_tsgxssl_crypto.lib -Force
+    Copy-Item  ossl_static.pdb $SGXSSL_ROOT\package\lib\$Platform\$my_Configuration\ -Force
+    Copy-Item  include\openssl\* $SGXSSL_ROOT\package\include\openssl\ -Recurse -Force
+    Copy-Item  include\* $SGXSSL_ROOT\sgx\test_app\enclave\ -Recurse -Force
+
+    if ($BUILD_LEVEL -ne "CRYPTO_ONLY")
+    {
+        set-location $SGXSSL_ROOT\sgx
+        MSBUILD SGXOpenSSLLibrary.sln /p:Configuration=$my_Configuration /p:Platform=$Platform /t:Rebuild
+        Copy-Item $Platform\$my_Configuration\libsgx_tsgxssl.lib $SGXSSL_ROOT\package\lib\$Platform\$my_Configuration\ -Force
+        Copy-Item $Platform\$my_Configuration\libsgx_usgxssl.lib $SGXSSL_ROOT\package\lib\$Platform\$my_Configuration\ -Force
+        if ($my_Configuration -eq "debug")
+        {
+            Copy-Item  libsgx_tsgxssl\$Platform\$my_Configuration\libsgx_tsgxssl.pdb $SGXSSL_ROOT\package\lib\$Platform\$my_Configuration\ -Force
+            Copy-Item  libsgx_usgxssl\$Platform\$my_Configuration\libsgx_usgxssl.pdb $SGXSSL_ROOT\package\lib\$Platform\$my_Configuration\ -Force
+        }
+        if ($BUILD_LEVEL -ne "SKIP_TEST")
+        {
+            set-location $Platform\$my_Configuration
+            & .\TestApp.exe
+            if ($LASTEXITCODE -ne 0) {
+                Write-Error 'TestApp Execution failed'
+                Exit 1
+            }
+        }
+    }
+
+} catch {
+    Write-Output $_.ToString()
+    Write-Output $_.ScriptStackTrace
+    Exit 1
+} finally  {
+    set-location $SGXSSL_ROOT
+}
+Exit 0

--- a/Windows/prepare-ossl.ps1
+++ b/Windows/prepare-ossl.ps1
@@ -1,0 +1,74 @@
+#
+# Copyright (C) 2011-2023 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+
+
+#=========================================#
+# Do not edit this script below this line #
+#=========================================#
+
+Param(
+    [string]$OSSL_URL_PATH = "https://www.openssl.org/source"
+    ,[Parameter(mandatory=$false)][string]$OPENSSL_VERSION = "openssl-3.0.10"
+)
+
+try {
+    $SGXSSL_ROOT = Get-Location
+    $full_openssl_url = "$OSSL_URL_PATH/$OPENSSL_VERSION.tar.gz"
+    $full_openssl_hash_url = "$full_openssl_url.sha256"
+    $downloaded_ossl_file = "$SGXSSL_ROOT/../openssl_source/$OPENSSL_VERSION.tar.gz"
+    $downloaded_osslhash_file = "$downloaded_ossl_file.sha256"
+   
+
+    if (-not (Test-Path -path $downloaded_ossl_file))
+    {
+        Write-Output "Downloading $OPENSSL_VERSION code from remote server..."
+        [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true};
+        (New-Object Net.WebClient).DownloadFile($full_openssl_url, $downloaded_ossl_file)
+        (New-Object Net.WebClient).DownloadFile($full_openssl_hash_url, $downloaded_osslhash_file)
+
+        $opensslfilehash = (Get-FileHash $downloaded_ossl_file).Hash.ToLower()
+        $expected_hash = (Get-Content $downloaded_osslhash_file  | Select-String -Pattern $opensslfilehash).ToString().Trim()
+        if ($opensslfilehash -ne $expected_hash) 
+        {
+            Write-Output "Error:  expected $expected_hash, while got file hash:", $opensslfilehash
+            Exit 1
+        } else {
+            Write-Output "$downloaded_ossl_file code was downloaded and verified."
+        }
+    }
+} catch {
+    Write-Output $_.ToString()
+    Write-Output $_.ScriptStackTrace
+    Exit 1
+} finally  {
+    set-location $SGXSSL_ROOT
+}
+Exit 0


### PR DESCRIPTION
1. build.ps1: main build script
` > .\build.ps1 openssl-3.0.12`
2. build_pkg.ps1: subroutine build script, called by build.ps1
3. prepare-ossl.ps1: script to download OpenSSL code from the remote server
` > .\prepare-ossl.ps1 -OPENSSL_VERSION openssl-3.0.12`