### PR TITLE
Upgrade to OpenSSL 3.0.17

### DIFF
--- a/Linux/Makefile
+++ b/Linux/Makefile
@@ -64,7 +64,7 @@ clean:
 	rm -rf $(PACKAGE_LIB)/$(OPENSSL_LIB) $(PACKAGE_INC)/openssl/
 	rm -rf $(PACKAGE_LIB)/cve_2020_0551_load
 	rm -rf $(PACKAGE_LIB)/cve_2020_0551_cf
-	$(MAKE) -C ../openssl_source/ clean
+	#$(MAKE) -C ../openssl_source/ clean
 
 test:
 	$(MAKE) -C sgx/ test
@@ -80,8 +80,8 @@ endif
 	mkdir -p $(DESTDIR)/include/
 	cp -prf $(PACKAGE_LIB)/*  $(DESTDIR)/lib64/
 	cp -prf $(PACKAGE_INC)/* $(DESTDIR)/include/
-	$(MAKE) -C ../openssl_source/ install
+	#$(MAKE) -C ../openssl_source/ install
 
 uninstall:
 	rm -rf $(DESTDIR)/
-	$(MAKE) -C ../openssl_source/ uninstall
+	#$(MAKE) -C ../openssl_source/ uninstall

--- a/Linux/Makefile
+++ b/Linux/Makefile
@@ -31,6 +31,7 @@
 include buildenv.mk
 include sgx/buildenv.mk
 LINUX_SGX_BUILD ?= 0
+FIPS ?= 0
 EMPTY_SRC = check_lvi_toolset
 .PHONY: sgxssl sgxssl_no_mitigation clean install uninstall
 

--- a/Linux/Makefile
+++ b/Linux/Makefile
@@ -64,7 +64,7 @@ clean:
 	rm -rf $(PACKAGE_LIB)/$(OPENSSL_LIB) $(PACKAGE_INC)/openssl/
 	rm -rf $(PACKAGE_LIB)/cve_2020_0551_load
 	rm -rf $(PACKAGE_LIB)/cve_2020_0551_cf
-	#$(MAKE) -C ../openssl_source/ clean
+	$(MAKE) -C ../openssl_source/ clean
 
 test:
 	$(MAKE) -C sgx/ test
@@ -80,8 +80,8 @@ endif
 	mkdir -p $(DESTDIR)/include/
 	cp -prf $(PACKAGE_LIB)/*  $(DESTDIR)/lib64/
 	cp -prf $(PACKAGE_INC)/* $(DESTDIR)/include/
-	#$(MAKE) -C ../openssl_source/ install
+	$(MAKE) -C ../openssl_source/ install
 
 uninstall:
 	rm -rf $(DESTDIR)/
-	#$(MAKE) -C ../openssl_source/ uninstall
+	$(MAKE) -C ../openssl_source/ uninstall

--- a/Linux/build_openssl.sh
+++ b/Linux/build_openssl.sh
@@ -36,11 +36,7 @@
 SGXSSL_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 echo $SGXSSL_ROOT
 
-if [[ "$*" == *"fips"* ]] ; then
-	OPENSSL_VERSION=`ls $SGXSSL_ROOT/../openssl_source/*3.1.*.tar.gz | head -1 | grep -o '[^/]*$' | sed -s -- 's/\.tar\.gz//'`
-else
-	OPENSSL_VERSION=`ls $SGXSSL_ROOT/../openssl_source/*3.0.*.tar.gz | head -1 | grep -o '[^/]*$' | sed -s -- 's/\.tar\.gz//'`
-fi
+OPENSSL_VERSION=`ls $SGXSSL_ROOT/../openssl_source/*3.0.*.tar.gz | head -1 | grep -o '[^/]*$' | sed -s -- 's/\.tar\.gz//'`
 if [ "$OPENSSL_VERSION" == "" ]
 then
 	echo "In order to run this script, the OpenSSL tar.gz package must be located in the openssl_source/ directory."

--- a/Linux/build_openssl.sh
+++ b/Linux/build_openssl.sh
@@ -36,10 +36,14 @@
 SGXSSL_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 echo $SGXSSL_ROOT
 
-OPENSSL_VERSION=`ls $SGXSSL_ROOT/../openssl_source/*3.1.*.tar.gz | head -1 | grep -o '[^/]*$' | sed -s -- 's/\.tar\.gz//'`
-if [ "$OPENSSL_VERSION" == "" ] 
+if [[ "$*" == *"fips"* ]] ; then
+	OPENSSL_VERSION=`ls $SGXSSL_ROOT/../openssl_source/*3.1.*.tar.gz | head -1 | grep -o '[^/]*$' | sed -s -- 's/\.tar\.gz//'`
+else
+	OPENSSL_VERSION=`ls $SGXSSL_ROOT/../openssl_source/*3.0.*.tar.gz | head -1 | grep -o '[^/]*$' | sed -s -- 's/\.tar\.gz//'`
+fi
+if [ "$OPENSSL_VERSION" == "" ]
 then
-	echo "In order to run this script, OpenSSL tar.gz package must be located in openssl_source/ directory."
+	echo "In order to run this script, the OpenSSL tar.gz package must be located in the openssl_source/ directory."
 	exit 1
 fi
 echo $OPENSSL_VERSION

--- a/Linux/sgx/Makefile
+++ b/Linux/sgx/Makefile
@@ -64,9 +64,8 @@ ifneq ($(CRYPTO_ONLY), 1)
 
 ifeq ($(LINUX_SGX_BUILD), 0)
 ifneq ($(NO_THREADS), 1)
-# Don't build the test app by default in FIPS mode since it depends on
-# the FIPS provider.
-# Execute the install target first.
+# Don't build the test app in FIPS mode since it depends on the FIPS provider,
+# which is not ready yet.
 ifneq ($(FIPS), 1)
 	$(MAKE) -C $(TEST_DIR) all
 endif

--- a/Linux/sgx/libsgx_tsgxssl/Makefile
+++ b/Linux/sgx/libsgx_tsgxssl/Makefile
@@ -87,9 +87,9 @@ endif
 endif
 
 ifeq ($(FIPS), 1)
-SGXSSL_ADDTIONAL_EDL_PATH=$(PACKAGE_INC)/filefunc
+SGXSSL_ADDITIONAL_EDL_PATH=$(PACKAGE_INC)/filefunc
 else
-SGXSSL_ADDTIONAL_EDL_PATH=$(PACKAGE_INC)/nofilefunc
+SGXSSL_ADDITIONAL_EDL_PATH=$(PACKAGE_INC)/nofilefunc
 endif
 
 SGX_EDL_FILE := $(PACKAGE_INC)/sgx_tsgxssl.edl
@@ -122,19 +122,19 @@ $(shell mkdir -p $(OBJDIR))
 all: $(TRUSTED_LIB)
 
 ######## sgx_tsgxssl Objects ########
-sgx_tsgxssl_t.c: $(SGX_EDGER8R) $(SGX_EDL_FILE)
-	$(SGX_EDGER8R) --header-only --trusted $(SGX_EDL_FILE) --search-path $(SGX_SDK_INC) --search-path $(SGXSSL_ADDTIONAL_EDL_PATH)
+sgx_tsgxssl_t.h: $(SGX_EDGER8R) $(SGX_EDL_FILE)
+	$(SGX_EDGER8R) --header-only --trusted $(SGX_EDL_FILE) --search-path $(SGX_SDK_INC) --search-path $(SGXSSL_ADDITIONAL_EDL_PATH)
 	@echo "GEN  =>  $@"
 
 sgx_tsgxssl_t.o: sgx_tsgxssl_t.c
 	$(VCC) $(Sgx_tssl_C_Flags) -c $< -o $@
 	@echo "CC   <=  $<"
 
-$(OBJDIR)/%.o : %.cpp sgx_tsgxssl_t.c
+$(OBJDIR)/%.o : %.cpp sgx_tsgxssl_t.h
 	$(VCXX) $(Sgx_tssl_Cpp_Flags) -c $< -o $@
 	@echo "CXX  <=  $<"
 
-$(OBJDIR)/%.o : %.c sgx_tsgxssl_t.c
+$(OBJDIR)/%.o : %.c sgx_tsgxssl_t.h
 	$(VCC) $(Sgx_tssl_C_Flags) -c $< -o $@
 	@echo "CC  <=  $<"
 
@@ -142,7 +142,7 @@ $(OBJDIR)/%.o : %.S
 	$(VCC) $(Common_C_Cpp_Flags) -c $< -o $@
 	@echo "CC  <=  $<"
 
-$(TRUSTED_LIB): sgx_tsgxssl_t.c $(Sgx_tssl_Cpp_Objects) $(Sgx_tssl_C_Objects) $(Sgx_tssl_S_Objects)
+$(TRUSTED_LIB): sgx_tsgxssl_t.h $(Sgx_tssl_Cpp_Objects) $(Sgx_tssl_C_Objects) $(Sgx_tssl_S_Objects)
 	ar rcs $(TRUSTED_LIB) $(Sgx_tssl_Cpp_Objects) $(Sgx_tssl_C_Objects) $(Sgx_tssl_S_Objects) 
 	@echo "LINK =>  $@"
 	@cp $@ $(PACKAGE_LIB)/$(TRUSTED_LIB)

--- a/Linux/sgx/libsgx_tsgxssl/texceptions.c
+++ b/Linux/sgx/libsgx_tsgxssl/texceptions.c
@@ -33,6 +33,7 @@
 #include <sgx_trts_exception.h>
 #include <sgx_cpuid.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "tcommon.h"
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ sudo make install
 ```
 
 ## Note for Version 3.*
-----------------------
+
 To use the trusted cryptography library with SGX SSL/OpenSSL 3.*, especially for the multithreaded enclaves, you may need to increase the enclave heap size adjusting the enclave signing configuration XML file:
 ```
 ...
@@ -90,7 +90,6 @@ To use the trusted cryptography library with SGX SSL/OpenSSL 3.*, especially for
 ```
 
 ## OpenSSL FIPS Provider
-----------------------
 
 As an experimental feature, the SGX SDK supports building the SGX SSL library using the OpenSSL FIPS provider, instead of the default provider. Note: This feature is only supported on Linux and OpenSSL 3.1.6. You must download two separate OpenSSL packages: one from the OpenSSL 3.0 series and one for OpenSSL 3.1.6.
 To build and install the Intel® SGX SSL package and the OpenSSL FIPS provider run:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/intel/intel-sgx-ssl/badge)](https://securityscorecards.dev/viewer/?uri=github.com/intel/intel-sgx-ssl)
 
-Intel® Software Guard Extensions SSL
+Intel® Software Guard Extensions SSL (SGX SSL)
 ================================================
 
 Introduction
@@ -8,7 +8,7 @@ Introduction
 The Intel® Software Guard Extensions SSL (Intel® SGX SSL) cryptographic library is intended to provide cryptographic services for Intel® Software Guard Extensions (SGX) enclave applications.
 The Intel® SGX SSL cryptographic library is based on the underlying OpenSSL* Open Source project, providing a full-strength general purpose cryptography library.
 
-This branch supports OpenSSL version 3.1.*, but works in 1.1.1 compatible mode. 
+This branch supports the OpenSSL 3.0 series, but works in 1.1.1 compatible mode.
 
 License
 -------
@@ -22,10 +22,11 @@ Documentation
   * [Windows developer guide](Windows/package/docs/Intel(R)%20Software%20Guard%20Extensions%20SSL%20Library%20Windows%20Developer%20Guide.pdf)
 
 
-Build Intel® SGX SSL package
-----------------------------
-Windows
-----------------------------
+Building the Intel® SGX SSL package
+-----------------------------------
+
+## Windows
+
 ### Prerequisites
 - Microsoft Visual Studio 2019
 - Perl
@@ -34,32 +35,35 @@ Windows
 
  (Note: Perl, NASM need to be included in machine's PATH variable)
 
-To build Intel® SGX SSL package in Windows OS:
-1. Download OpenSSL package into openssl_source/ directory. (tar.gz package, e.g. openssl-3.1.*.tar.gz)
-2. Download and install latest SGX SDK from [Intel Developer Zone](https://software.intel.com/en-us/sgx-sdk/download). You can find installation guide from the same website.
+### Building
+
+To build the Intel® SGX SSL package in Windows OS:
+1. Download the OpenSSL package into the openssl_source/ directory. (tar.gz package, e.g. openssl-3.0.*.tar.gz)
+2. Download and install the latest SGX SDK from [Intel Developer Zone](https://software.intel.com/en-us/sgx-sdk/download). You can find the installation guide in the same website.
 3. Change the directory to the SGXSSL path and enter the following command:
 ```
-build_all.cmd <OPENSSL_VERSION> [default == openssl-3.1.0]
+build_all.cmd <OPENSSL_VERSION> [default == openssl-3.0.17]
 ```
-This will build the Intel® SGX SSL libraries (libsgx_tsgxssl.lib, libsgx_usgxssl.lib, libsgx_tsgxssl_crypto.lib), which can be found in package/lib/{Win32|X64}/{debug|release}/. And the version with CVE-2020-0551 Mitigation enabled can be found in package/lib/X64/{CVE-2020-0551-CF-Release|CVE-2020-0551-Load-Release}/.
+This builds the Intel® SGX SSL libraries (libsgx_tsgxssl.lib, libsgx_usgxssl.lib, libsgx_tsgxssl_crypto.lib) that can be found in package/lib/{Win32|X64}/{debug|release}/. The version with CVE-2020-0551 mitigation enabled can be found in package/lib/X64/{CVE-2020-0551-CF-Release|CVE-2020-0551-Load-Release}/.
 
-Linux
-----------------------------
+## Linux
+
 ### Prerequisites
 - Perl
 - Toolchain with mitigation (refer to [SGX Linux README](https://github.com/intel/linux-sgx/blob/master/README.md))
-- Intel(R) SGX Linux latest release, including SDK, PSW, and driver
+- Intel(R) SGX Linux latest release, including SDK and PSW.
 
-To build Intel® SGX SSL package in Linux OS:
-=======
-1. Download OpenSSL 3.1.* package into openssl_source/ directory. (tar.gz package, e.g. openssl-3.1.*.tar.gz)
-2. Download and install latest SGX SDK from [01.org](https://download.01.org/intel-sgx/latest/). You can find the installation guide in the same website.
+### Building
+
+To build the Intel® SGX SSL package in Linux OS:
+1. Download the OpenSSL 3.0.* package into openssl_source/ directory. (tar.gz package, e.g. openssl-3.0.*.tar.gz)
+2. Download and install the latest SGX SDK from [01.org](https://download.01.org/intel-sgx/latest/). You can find the installation guide in the same website.
 3. Source SGX SDK's environment variables.
-4. Cd to Linux/ directory and run:
+4. Change into the Linux/ directory and run:
 ```
 make all test
 ```
-This will build and test the Intel® SGX SSL libraries (libsgx_tsgxssl.a, libsgx_usgxssl.a, libsgx_tsgxssl_crypto.a), which can be found in package/lib64/. And the Intel® SGX SSL trusted libraries (libsgx_tsgxssl.lib,  libsgx_tsgxssl_crypto.lib) with CVE-2020-0551 Mitigation enabled can be found in package/lib64/{cve_2020_0551_cf|cve_2020_0551_load}/.
+This builds and tests the Intel® SGX SSL libraries (libsgx_tsgxssl.a, libsgx_usgxssl.a, libsgx_tsgxssl_crypto.a), which can be found in package/lib64/. The Intel® SGX SSL trusted libraries (libsgx_tsgxssl.lib,  libsgx_tsgxssl_crypto.lib) with CVE-2020-0551 mitigation enabled can be found in package/lib64/{cve_2020_0551_cf|cve_2020_0551_load}/.
 
 ### Available `make` flags:
 - DEBUG={1,0}: Libraries build mode, with debug symbols or without. Default ``0``.
@@ -67,7 +71,8 @@ This will build and test the Intel® SGX SSL libraries (libsgx_tsgxssl.a, libsgx
 - SGX_MODE={HW,SIM}: User can take ``SIM`` to run the unit test on non-SGX platform if necessary. Default ``HW``. 
 - DESTDIR=\<PATH\>: Directory realpath to install Intel® SGX SSL libraries in. Default ``/opt/intel/sgxssl/``. 
 - VERBOSE={1,0}: Makefile verbose mode. Print compilation commands before executing it. Default ``0``.
-- OSSL3ONLY={1,0}: USE only OpenSSL 3.x APIs, and legacy functions will not be valid. Default ``0``.
+- OSSL3ONLY={1,0}: Use only OpenSSL 3.x APIs, and legacy functions will not be valid. Default ``0``.
+- FIPS={1,0}: Use the OpenSSL FIPS provider as an experimental feature. Default ``0``.
 
 To install Intel® SGX SSL libraries in Linux OS, run:
 ```
@@ -75,12 +80,28 @@ make all test
 sudo make install
 ```
 
-Note for Version 3.*
---------------------
-To use the trusted cryptography library with SGX SSL/OpenSSL 3.*, it possibly needs to increase the value in the enclave signing configuration XML file:
+## Note for Version 3.*
+----------------------
+To use the trusted cryptography library with SGX SSL/OpenSSL 3.*, especially for the multithreaded enclaves, you may need to increase the enclave heap size adjusting the enclave signing configuration XML file:
 ```
 ...
 <HeapMaxSize>...</HeapMaxSize>
 ...
 ```
-, especially for the enclave with multithreads. 
+
+## OpenSSL FIPS Provider
+----------------------
+
+As an experimental feature, the SGX SDK supports building the SGX SSL library using the OpenSSL FIPS provider, instead of the default provider. Note: This feature is only supported on Linux and OpenSSL 3.1.6. You must download two separate OpenSSL packages: one from the OpenSSL 3.0 series and one for OpenSSL 3.1.6.
+To build and install the Intel® SGX SSL package and the OpenSSL FIPS provider run:
+
+```
+make all FIPS=1
+sudo make install
+```
+
+You may build and run one or both test programs that utilize the FIPS provider. The `FIPS=1` option must be specified; otherwise, a linker error will occur.
+```
+make test FIPS=1
+make fips_test FIPS=1
+```

--- a/openssl_source/Makefile
+++ b/openssl_source/Makefile
@@ -62,7 +62,7 @@ fips:
 	mkdir -p $(OSSL_FIPS_INSTALL_DIR)
 	mkdir -p $(OSSL_FIPS_BUILD_DIR)
 	tar xvf $(OPENSSL_VERSION).tar.gz -C $(OSSL_FIPS_SOURCE_DIR) --strip-components=1  > /dev/null
-	cd $(OSSL_FIPS_BUILD_DIR) && $(OSSL_FIPS_SOURCE_DIR)/Configure enable-fips --prefix=$(OSSL_FIPS_INSTALL_DIR) && \
+	cd $(OSSL_FIPS_BUILD_DIR) && $(OSSL_FIPS_SOURCE_DIR)/Configure enable-fips --with-rand-seed=rdcpu --prefix=$(OSSL_FIPS_INSTALL_DIR) && \
 		$(MAKE) -j$(shell getconf _NPROCESSORS_ONLN) && $(MAKE) install_fips
 
 # Install the FIPS provider and its configuration file in the SGX SDK location

--- a/openssl_source/Makefile
+++ b/openssl_source/Makefile
@@ -67,9 +67,7 @@ fips:
 
 # Install the FIPS provider and its configuration file in the SGX SDK location
 install:
-ifeq ($(OSSL_FIPS_INSTALL_DIR_SET), 0)
-	$(error "Missing directory : $(OSSL_FIPS_INSTALL_DIR). Have you built the FIPS module yet?")
-endif
+ifeq ($(OSSL_FIPS_INSTALL_DIR_SET), 1)
 	@echo "*** Installing FIPS module"
 	@echo "install $(FIPSMODULE) -> $(SGX_SDK)/$(LIBDIR)/$(FIPSMODULE)"
 	cp -f $(OSSL_FIPS_INSTALL_DIR)/$(LIBDIR)/ossl-modules/$(FIPSMODULE) $(SGX_SDK)/$(LIBDIR)/$(FIPSMODULE).new
@@ -80,7 +78,8 @@ endif
 	@echo "install $(FIPSMODULECONF) -> $(SGX_SDK)/$(LIBDIR)/$(FIPSMODULECONF)"
 	echo "module-filename = $(SGX_SDK)/$(LIBDIR)/$(FIPSMODULE)" >> $(OSSL_FIPS_INSTALL_DIR)/ssl/$(FIPSMODULECONF)
 	cp -f $(OSSL_FIPS_INSTALL_DIR)/ssl/$(FIPSMODULECONF) $(SGX_SDK)/$(LIBDIR)/$(FIPSMODULECONF)
-	chmod 744 $(SGX_SDK)/$(LIBDIR)/$(FIPSMODULECONF)
+	chmod 644 $(SGX_SDK)/$(LIBDIR)/$(FIPSMODULECONF)
+endif
 
 # Remove the FIPS provider and configuration file from the SGX SDK location
 uninstall:
@@ -90,7 +89,7 @@ uninstall:
 
 	@echo "*** Uninstalling FIPS module configuration"
 	@echo "uninstall $(SGX_SDK)/$(LIBDIR)/$(FIPSMODULECONF)"
-	rm -rf $(SGX_SDK)/$(LIBDIR)/$(FIPSMODULECONF)
+	rm -f $(SGX_SDK)/$(LIBDIR)/$(FIPSMODULECONF)
 
 clean:
 ifeq ($(OSSL_FIPS_BUILD_DIR_SET), 1)

--- a/openssl_source/o_fopen.c
+++ b/openssl_source/o_fopen.c
@@ -25,7 +25,7 @@
 #  endif
 # endif
 
-#include "internal/e_os.h"
+#include "e_os.h"
 #include "internal/cryptlib.h"
 
 #if !defined(OPENSSL_NO_STDIO)

--- a/openssl_source/rand_lib.c
+++ b/openssl_source/rand_lib.c
@@ -18,7 +18,6 @@
 #include "crypto/rand.h"
 #include "crypto/cryptlib.h"
 #include "rand_local.h"
-#include "crypto/context.h"
 
 #ifndef FIPS_MODULE
 # include <stdio.h>
@@ -29,8 +28,7 @@
 # include <openssl/engine.h>
 # include "crypto/rand_pool.h"
 # include "prov/seeding.h"
-# include "internal/e_os.h"
-# include "internal/property.h"
+# include "e_os.h"
 
 # ifndef OPENSSL_NO_ENGINE
 /* non-NULL if default_RAND_meth is ENGINE-provided */
@@ -448,7 +446,7 @@ typedef struct rand_global_st {
  * Initialize the OSSL_LIB_CTX global DRBGs on first use.
  * Returns the allocated global data on success or NULL on failure.
  */
-void *ossl_rand_ctx_new(OSSL_LIB_CTX *libctx)
+static void *rand_ossl_ctx_new(OSSL_LIB_CTX *libctx)
 {
     RAND_GLOBAL *dgbl = OPENSSL_zalloc(sizeof(*dgbl));
 
@@ -505,9 +503,16 @@ void ossl_rand_ctx_free(void *vdgbl)
     OPENSSL_free(dgbl);
 }
 
+static const OSSL_LIB_CTX_METHOD rand_drbg_ossl_ctx_method = {
+    OSSL_LIB_CTX_METHOD_PRIORITY_2,
+    rand_ossl_ctx_new,
+    ossl_rand_ctx_free,
+};
+
 static RAND_GLOBAL *rand_get_global(OSSL_LIB_CTX *libctx)
 {
-    return ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_DRBG_INDEX);
+    return ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_DRBG_INDEX,
+                                 &rand_drbg_ossl_ctx_method);
 }
 
 static void rand_delete_thread_state(void *arg)
@@ -533,109 +538,29 @@ static EVP_RAND_CTX *rand_new_seed(OSSL_LIB_CTX *libctx)
 {
     EVP_RAND *rand;
     RAND_GLOBAL *dgbl = rand_get_global(libctx);
-    EVP_RAND_CTX *ctx = NULL;
-    const char *propq;
-    char *name, *props = NULL;
-    size_t props_len;
-    OSSL_PROPERTY_LIST *pl1, *pl2, *pl3 = NULL;
-
-    if (dgbl == NULL)
-        return NULL;
-    propq = dgbl->seed_propq;
-    if (dgbl->seed_name != NULL) {
-        name = dgbl->seed_name;
-    } else {
-        /*
-         * Default to our internal seed source.  This isn't part of the FIPS
-         * provider so we need to override any FIPS properties.
-         */
-        if (propq == NULL || *propq == '\0') {
-            propq = "-fips";
-        } else {
-            pl1 = ossl_parse_query(libctx, propq, 1);
-            if (pl1 == NULL) {
-                ERR_raise(ERR_LIB_RAND, RAND_R_INTERNAL_ERROR); 
-                return NULL;
-            }
-            pl2 = ossl_parse_query(libctx, "-fips", 1);
-            if (pl2 == NULL) {
-                ossl_property_free(pl1);
-                ERR_raise(ERR_LIB_RAND, ERR_R_INTERNAL_ERROR);
-                return NULL;
-            }
-            pl3 = ossl_property_merge(pl2, pl1);
-            ossl_property_free(pl1);
-            ossl_property_free(pl2);
-            if (pl3 == NULL) {
-                ERR_raise(ERR_LIB_RAND, ERR_R_INTERNAL_ERROR);
-                return NULL;
-            }
-            props_len = ossl_property_list_to_string(libctx, pl3, NULL, 0);
-            if (props_len == 0) {
-                /* Shouldn't happen since we added a query element */
-                ERR_raise(ERR_LIB_RAND, ERR_R_INTERNAL_ERROR);
-                goto err;
-            } else {
-                props = OPENSSL_malloc(props_len);
-                if (props == NULL) {
-                    ERR_raise(ERR_LIB_RAND, ERR_R_MALLOC_FAILURE);
-                    goto err;
-                }
-                if (ossl_property_list_to_string(libctx, pl3,
-                                                 props, props_len) == 0) {
-                    ERR_raise(ERR_LIB_RAND, ERR_R_INTERNAL_ERROR);
-                    goto err;
-                }
-                ossl_property_free(pl3);
-                pl3 = NULL;
-                propq = props;
-            }
-        }
-        name = "SEED-SRC";
-    }
-
+    EVP_RAND_CTX *ctx;
+    char *name;
 
     if (dgbl == NULL)
         return NULL;
     name = dgbl->seed_name != NULL ? dgbl->seed_name : "SEED-SRC";
     rand = EVP_RAND_fetch(libctx, name, dgbl->seed_propq);
-
     if (rand == NULL) {
         ERR_raise(ERR_LIB_RAND, RAND_R_UNABLE_TO_FETCH_DRBG);
-        goto err;
+        return NULL;
     }
     ctx = EVP_RAND_CTX_new(rand, NULL);
     EVP_RAND_free(rand);
     if (ctx == NULL) {
         ERR_raise(ERR_LIB_RAND, RAND_R_UNABLE_TO_CREATE_DRBG);
-        goto err;
+        return NULL;
     }
     if (!EVP_RAND_instantiate(ctx, 0, 0, NULL, 0, NULL)) {
         ERR_raise(ERR_LIB_RAND, RAND_R_ERROR_INSTANTIATING_DRBG);
-        goto err;
+        EVP_RAND_CTX_free(ctx);
+        return NULL;
     }
-    OPENSSL_free(props);
     return ctx;
- err:
-    EVP_RAND_CTX_free(ctx);
-    ossl_property_free(pl3);
-    OPENSSL_free(props);
-    return NULL;
-}
-
-EVP_RAND_CTX *ossl_rand_get0_seed_noncreating(OSSL_LIB_CTX *ctx)
-{
-    RAND_GLOBAL *dgbl = rand_get_global(ctx);
-    EVP_RAND_CTX *ret;
-
-    if (dgbl == NULL)
-        return NULL;
-
-    if (!CRYPTO_THREAD_read_lock(dgbl->lock))
-        return NULL;
-    ret = dgbl->seed;
-    CRYPTO_THREAD_unlock(dgbl->lock);
-    return ret;
 }
 #endif
 
@@ -813,46 +738,6 @@ EVP_RAND_CTX *RAND_get0_private(OSSL_LIB_CTX *ctx)
     return rand;
 }
 
-#ifdef FIPS_MODULE
-EVP_RAND_CTX *ossl_rand_get0_private_noncreating(OSSL_LIB_CTX *ctx)
-{
-    RAND_GLOBAL *dgbl = rand_get_global(ctx);
-
-    if (dgbl == NULL)
-        return NULL;
-
-    return CRYPTO_THREAD_get_local(&dgbl->private);
-}
-#endif
-
-int RAND_set0_public(OSSL_LIB_CTX *ctx, EVP_RAND_CTX *rand)
-{
-    RAND_GLOBAL *dgbl = rand_get_global(ctx);
-    EVP_RAND_CTX *old;
-    int r;
-
-    if (dgbl == NULL)
-        return 0;
-    old = CRYPTO_THREAD_get_local(&dgbl->public);
-    if ((r = CRYPTO_THREAD_set_local(&dgbl->public, rand)) > 0)
-        EVP_RAND_CTX_free(old);
-    return r;
-}
-
-int RAND_set0_private(OSSL_LIB_CTX *ctx, EVP_RAND_CTX *rand)
-{
-    RAND_GLOBAL *dgbl = rand_get_global(ctx);
-    EVP_RAND_CTX *old;
-    int r;
-
-    if (dgbl == NULL)
-        return 0;
-    old = CRYPTO_THREAD_get_local(&dgbl->private);
-    if ((r = CRYPTO_THREAD_set_local(&dgbl->private, rand)) > 0)
-        EVP_RAND_CTX_free(old);
-    return r;
-}
-
 #ifndef FIPS_MODULE
 static int random_set_string(char **p, const char *s)
 {
@@ -959,7 +844,7 @@ int RAND_set_seed_source_type(OSSL_LIB_CTX *ctx, const char *seed,
 
     if (dgbl == NULL)
         return 0;
-    if (dgbl->seed != NULL) {
+    if (dgbl->primary != NULL) {
         ERR_raise(ERR_LIB_CRYPTO, RAND_R_ALREADY_INSTANTIATED);
         return 0;
     }


### PR DESCRIPTION
Upgrade the SGX-SSL library to utilize OpenSSL 3.0.17 while leaving OpenSSL 3.1.6 to provide FIPS provider support.