### PR TITLE
Fix issue #148: Null-Pointer Dereference in test_app

### DIFF
--- a/Linux/sgx/test_app/enclave/tests/threadstest.c
+++ b/Linux/sgx/test_app/enclave/tests/threadstest.c
@@ -120,8 +120,9 @@ static int wait_for_thread(thread_t thread)
 void new_thread_func()
 {
     printf("in new thread, id: %llu\n",sgx_thread_self());
-    if (NULL == func) {
+    if (func == NULL) {
         fprintf(stderr, "Thread function not initialized\n");
+        busy_wait = 0;
         return;
     }
     func();

--- a/Linux/sgx/test_app/enclave/tests/threadstest.c
+++ b/Linux/sgx/test_app/enclave/tests/threadstest.c
@@ -119,9 +119,13 @@ static int wait_for_thread(thread_t thread)
 
 void new_thread_func()
 {
-	printf("in new thread, id: %llu\n",sgx_thread_self());
-	func();
-	busy_wait = 0;
+    printf("in new thread, id: %llu\n",sgx_thread_self());
+    if (NULL == func) {
+        fprintf(stderr, "Thread function not initialized\n");
+        return;
+    }
+    func();
+    busy_wait = 0;
 }
 
 static int test_lock(void)


### PR DESCRIPTION
Fix for issue #148: Don't call function pointer "func" if it isn't initialized.