### PR TITLE
Document limitation of FIPS provider support relying on default configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ make test FIPS=1
 make fips_test FIPS=1
 ```
 
-FIPS support was introduced as an experimental feature, and the current design has a limitation that relies on the default OpenSSL and FIPS provider configuration files.
+FIPS support was introduced as an experimental feature, and the current design relies on OpenSSL’s default configuration lookup for `openssl.cnf` (which in turn includes the FIPS module configuration, e.g., `fipsmodule.cnf`).
 
 In the FIPS build of SGX-SSL, an attacker with write access to the directory from which the enclave is executed could modify the FIPS provider configuration file. This introduces a potential integrity risk, as the configuration may be altered outside the trusted computing base.
 

--- a/README.md
+++ b/README.md
@@ -104,3 +104,9 @@ You may build and run one or both test programs that utilize the FIPS provider. 
 make test FIPS=1
 make fips_test FIPS=1
 ```
+
+FIPS support was introduced as an experimental feature, and the current design has a limitation that relies on the default OpenSSL and FIPS provider configuration files.
+
+In the FIPS build of SGX-SSL, an attacker with write access to the directory from which the enclave is executed could modify the FIPS provider configuration file. This introduces a potential integrity risk, as the configuration may be altered outside the trusted computing base.
+
+At this time, we are documenting this behavior as a known limitation and will assess whether further action is warranted based on future customer requirements.

--- a/README.md
+++ b/README.md
@@ -107,6 +107,6 @@ make fips_test FIPS=1
 
 FIPS support was introduced as an experimental feature, and the current design relies on OpenSSL’s default configuration lookup for `openssl.cnf` (which in turn includes the FIPS module configuration, e.g., `fipsmodule.cnf`).
 
-In the FIPS build of SGX-SSL, an attacker with write access to the directory from which the enclave is executed could modify the FIPS provider configuration file. This introduces a potential integrity risk, as the configuration may be altered outside the trusted computing base.
+In the FIPS build of Intel® SGX SSL, an attacker with write access to the untrusted filesystem path(s) used for OpenSSL configuration (for example `openssl.cnf` and any included `fipsmodule.cnf`) could modify those files. This introduces a potential integrity risk, as configuration may be altered outside the trusted computing base.
 
 At this time, we are documenting this behavior as a known limitation and will assess whether further action is warranted based on future customer requirements.


### PR DESCRIPTION
Document the limitation of FIPS provider support relying on the default OpenSSL and FIPS provider configuration files.